### PR TITLE
updated to make it work without errors, in jenkins, this used to give…

### DIFF
--- a/src/main/webapp/javascript/performanceGraph.js
+++ b/src/main/webapp/javascript/performanceGraph.js
@@ -1,7 +1,7 @@
 /* performance graph */
-jQuery(document).ready(function() {
+$(document).ready(function() {
 
-	jQuery('#graphArea').highcharts({
+	$('#graphArea').highcharts({
 		chart : {
 			type : 'line'
 		},


### PR DESCRIPTION
This was giving an error in our jenkins box
After updating it to $ format, the error is resolved

May be it resolves: 
http://stackoverflow.com/questions/32011248/highcharts-uncaught-typeerror-highcharts-is-not-a-function
and
https://github.com/TrueDub/cucumber-performance/issues/9
